### PR TITLE
Update Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'http://rubygems.org'
 
-gem 'activerecord', :require => 'active_record'
+gem 'activerecord', '~> 4.2', :require => 'active_record'
 gem 'sinatra-activerecord', :require => 'sinatra/activerecord'
 
 gem 'sinatra'


### PR DESCRIPTION
ran into the issue where ActiveRecord::Migrator.needs_migration? is not a method in the active record version students were using. this will prevent that from happening. @DanielSeehausen 