### PR TITLE
ActiveRecord Version Change from 5.2 to 4.2 in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'http://rubygems.org'
 
-gem 'activerecord', :require => 'active_record'
+gem 'activerecord', '4.2', :require => 'active_record'
 gem 'sinatra-activerecord', :require => 'sinatra/activerecord'
 
 gem 'sinatra'


### PR DESCRIPTION
Changed ActiveRecord version in Gemfile from 5.2 to 4.2. ActiveRecord::Migrator.needs_migration? wasn't working in the config.ru file because 5.2 moved a lot of those methods to the ActiveRecord::MigrationContext class. However, I tried changing ActiveRecord::Migrator to ActiveRecord::MigrationContext and still couldn't get that method to work so I just changed the version on the gemfile for now. Here's docs on the ActiveRecord version change:

https://github.com/influitive/apartment/pull/523 