### PR TITLE
Enforce ActiveRecord 4.2.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'http://rubygems.org'
 
-gem 'activerecord', :require => 'active_record'
+gem 'activerecord', '4.2.5', :require => 'active_record'
 gem 'sinatra-activerecord', :require => 'sinatra/activerecord'
 
 gem 'sinatra'


### PR DESCRIPTION
For #21 
I chose `4.2.5` to be consistent with what is taught in [Sinatra Activerecord Setup](https://github.com/learn-co-curriculum/sinatra-activerecord-setup)