### PR TITLE
removed pre-written action, get "/" do, from application_controller.rb

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,7 +3,7 @@ class ApplicationController < Sinatra::Base
     set :public_folder, 'public'
     set :views, 'app/views'
   end
-  get '/' do
-    erb :index
-  end
+
+  # code actions here!
+
 end


### PR DESCRIPTION
Removed
```
get '/' do
  erb :index
end
```
as spec is expecting '/profiles' for the index page and it is causing student confusion.